### PR TITLE
fix for reading serializer snapshots bigger than buffer size

### DIFF
--- a/src/main/scala/io/findify/flinkadt/api/serializer/CoproductSerializer.scala
+++ b/src/main/scala/io/findify/flinkadt/api/serializer/CoproductSerializer.scala
@@ -49,7 +49,7 @@ object CoproductSerializer {
     override def readSnapshot(readVersion: Int, in: DataInputView, userCodeClassLoader: ClassLoader): Unit = {
       val len = in.readInt()
       val bytes = new Array[Byte](len)
-      in.read(bytes)
+      in.readFully(bytes)
       val buffer = new ByteArrayInputStream(bytes)
       val objStream = new ObjectInputStream(buffer)
       context = objStream.readObject().asInstanceOf[SealedTrait[TypeSerializer, T]]

--- a/src/main/scala/io/findify/flinkadt/api/serializer/ProductSerializer.scala
+++ b/src/main/scala/io/findify/flinkadt/api/serializer/ProductSerializer.scala
@@ -41,7 +41,7 @@ object ProductSerializer {
     override def readSnapshot(readVersion: Int, in: DataInputView, userCodeClassLoader: ClassLoader): Unit = {
       val len = in.readInt()
       val bytes = new Array[Byte](len)
-      in.read(bytes)
+      in.readFully(bytes)
       val buffer = new ByteArrayInputStream(bytes)
       val objStream = new ObjectInputStream(buffer)
       context = objStream.readObject().asInstanceOf[CaseClass[TypeSerializer, T]]


### PR DESCRIPTION
If the checkpoints are streamed from i.e. S3 the stream can be buffered, and if the the snapshot does not fit in the buffer it is not read fully and cannot be decoded.