### PR TITLE
Properly handle `null` in `MappedSerializer` equality check

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,16 @@ libraryDependencies ++= Seq(
   "org.typelevel"   %% "cats-core"        % "2.7.0"      % Test
 )
 
+// Ensure `TypeMapper` works for circe.
+// TODO provide as a separate module?
+libraryDependencies ++= {
+  val circeVersion = "0.14.1"
+  Seq(
+    "io.circe" %% "circe-core",
+    "io.circe" %% "circe-parser"
+  ).map(_ % circeVersion % Test)
+}
+
 // Macro libraries are based on major version.
 libraryDependencies ++= {
   if (scalaBinaryVersion.value.startsWith("2")) {

--- a/src/main/scala/io/findify/flinkadt/api/package.scala
+++ b/src/main/scala/io/findify/flinkadt/api/package.scala
@@ -18,6 +18,14 @@ package object api extends LowPrioImplicits {
 
   override protected val cache: mutable.Map[String, Typeclass[_]] = mutable.Map[String, TypeInformation[_]]()
 
+  /** Summon existing type information.
+    * Equivalent to `implicitly` / `summon` in Scala 2 / 3 respectively.
+    * @param ti Existing type information within scope.
+    * @tparam T Underlying type.
+    * @return Existing type information.
+    */
+  def typeInformation[T](implicit ti: TypeInformation[T]): TypeInformation[T] = ti
+
   implicit def into2ser[T](implicit ti: TypeInformation[T]): TypeSerializer[T] = ti.createSerializer(config)
 
   implicit def optionSerializer[T](implicit vs: TypeSerializer[T]): TypeSerializer[Option[T]] =

--- a/src/main/scala/io/findify/flinkadt/api/serializer/MappedSerializer.scala
+++ b/src/main/scala/io/findify/flinkadt/api/serializer/MappedSerializer.scala
@@ -1,20 +1,13 @@
 package io.findify.flinkadt.api.serializer
 
 import io.findify.flinkadt.api.serializer.MappedSerializer.{MappedSerializerSnapshot, TypeMapper}
-import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.common.typeutils.{
-  CompositeTypeSerializerSnapshot,
-  GenericTypeSerializerSnapshot,
-  SimpleTypeSerializerSnapshot,
-  TypeSerializer,
-  TypeSerializerSchemaCompatibility,
-  TypeSerializerSnapshot
-}
+import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerSchemaCompatibility, TypeSerializerSnapshot}
 import org.apache.flink.core.memory.{DataInputView, DataOutputView}
 import org.apache.flink.util.InstantiationUtil
 
 case class MappedSerializer[A, B](mapper: TypeMapper[A, B], ser: TypeSerializer[B]) extends SimpleSerializer[A] {
-  override def equals(obj: Any): Boolean = ser.equals(obj)
+  // Intentionally uses `==`, properly handles `null` during equality check.
+  override def equals(obj: Any): Boolean = ser == obj
 
   override def toString: String = ser.toString
 

--- a/src/test/scala/io/findify/flinkadt/CirceJsonTest.scala
+++ b/src/test/scala/io/findify/flinkadt/CirceJsonTest.scala
@@ -1,0 +1,26 @@
+package io.findify.flinkadt
+
+import io.circe.{parser, Json}
+import io.findify.flinkadt.api._
+import io.findify.flinkadt.api.serializer.MappedSerializer.TypeMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class CirceJsonTest extends AnyFlatSpec with Matchers {
+  import CirceJsonTest._
+
+  it should "derive type information & create serializer for Circe Json" in {
+    typeInformation[Json].createSerializer(null) shouldNot be(null)
+  }
+}
+
+object CirceJsonTest {
+  // TODO provide via separate module?
+  implicit val circeJsonMapper: TypeMapper[Json, String] = new TypeMapper[Json, String] {
+    override def map(a: Json): String = a.noSpaces
+
+    override def contramap(b: String): Json = parser
+      .parse(b)
+      .getOrElse(Json.Null)
+  }
+}


### PR DESCRIPTION
Addresses https://github.com/findify/flink-adt/issues/26. Can consider adding official `circe` support via a separate module later on.