### PR TITLE
Fix compilation when using Scala 3.3.x

### DIFF
--- a/src/main/scala/io/findify/flinkadt/api/serializer/MappedSerializer.scala
+++ b/src/main/scala/io/findify/flinkadt/api/serializer/MappedSerializer.scala
@@ -53,7 +53,7 @@ object MappedSerializer {
     override def readSnapshot(readVersion: Int, in: DataInputView, userCodeClassLoader: ClassLoader): Unit = {
       val mapperClazz = InstantiationUtil.resolveClassByName[TypeMapper[A, B]](in, userCodeClassLoader)
       mapper = InstantiationUtil.instantiate(mapperClazz)
-      val serClazz = InstantiationUtil.resolveClassByName(in, userCodeClassLoader)
+      val serClazz = InstantiationUtil.resolveClassByName[TypeSerializer[B]](in, userCodeClassLoader)
       ser = InstantiationUtil.instantiate(serClazz)
     }
 


### PR DESCRIPTION
Fixes compilation error when using Scala 3.3.x, based on the Open Community Build failure: https://github.com/VirtusLab/community-build3/actions/runs/4650721329/jobs/8230870972 
